### PR TITLE
Add command line args for debugmode

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,10 @@
 from app import app
+import sys
 
 if __name__ == "__main__":
-    app.run(debug=False)
+
+    debug = False
+    if len(sys.argv) > 1 and sys.argv[1].lower() == "debug":
+        debug = bool(sys.argv[1])
+    
+    app.run(debug=debug)


### PR DESCRIPTION
Closes #89 
@VanFossen 
If the start-up command is run with the parameter `debug` (not case sensitive), it will start in debug mode. Otherwise, it will not start in debug mode.